### PR TITLE
Controlled admin tree titles

### DIFF
--- a/catalog/models.py
+++ b/catalog/models.py
@@ -22,6 +22,15 @@ def search(term: str, model_type: Union[models.Model, models.Manager, models.Que
     ).order_by(F('is_name_start_by_term').desc(), *ordering or ('name', ))
 
 
+class AdminTreeDisplayMixin(object):
+
+    def get_admin_tree_title(self):
+        """
+        Returns string that used as title of entity in sidebar at admin panel
+        """
+        return '[{id}] {name}'.format(id=self.id, name=self.name)
+
+
 class CategoryManager(mptt_managers.TreeManager):
     def get_root_categories_by_products(self, products: models.QuerySet) -> dict:
         root_categories = self.root_nodes()
@@ -36,7 +45,7 @@ class CategoryManager(mptt_managers.TreeManager):
         }
 
 
-class AbstractCategory(mptt_models.MPTTModel):
+class AbstractCategory(mptt_models.MPTTModel, AdminTreeDisplayMixin):
 
     class Meta:
         abstract = True
@@ -94,7 +103,7 @@ class ProductManager(models.Manager):
         return self.get_queryset().get_by_category(category, ordering)
 
 
-class AbstractProduct(models.Model):
+class AbstractProduct(models.Model, AdminTreeDisplayMixin):
     """
     Product model.
     Defines basic functionality and primitives for Product in typical e-shop.

--- a/generic_admin/views.py
+++ b/generic_admin/views.py
@@ -334,7 +334,7 @@ class Tree(View, MultipleObjectMixin):
         # jsTree has restriction on the field's names.
         return [{
            'id': entity.id,
-           'text': '[ {id} ] {name}'.format(id=entity.id, name=entity.name),
+           'text': entity.get_admin_tree_title(),
            'children': is_category,  # if False, then lazy load switch off
            'a_attr': {  # it is <a> tag's attributes
                'href-site-page': entity.get_absolute_url(),


### PR DESCRIPTION
Этот PR позволяет определить метод `get_admin_tree_title` у моделей, которые нужно отображать в сайдбаре админки. Для моделей, у которых такой метод отсутствует, будет использоватся стандартный способ отображения: `[{id}] {name}`
Необходимо для https://trello.com/c/wb1bubgy/221-stb